### PR TITLE
Update RemoteTech Addon page

### DIFF
--- a/addons/RemoteTech.html
+++ b/addons/RemoteTech.html
@@ -228,6 +228,7 @@ of some of its suffixes.</p>
 </div>
 <div class="section" id="rtaddon">
 <h3>RTAddon<a class="headerlink" href="#rtaddon" title="Permalink to this headline">¶</a></h3>
+<p>Access structure RTAddon via <code class="docutils literal"><span class="pre">ADDONS:RT</span></code>.</p>
 <dl class="structure">
 <dt id="structure:RTADDON">
 <em class="property">structure </em><code class="descname">RTAddon</code><a class="headerlink" href="#structure:RTADDON" title="Permalink to this definition">¶</a></dt>


### PR DESCRIPTION
Add missing instruction on how to get access to the RTAddon structure.
That instruction was present on other addons but not here.